### PR TITLE
FEAT AND FIX #1 - Los montos de Notas de Crédito y Débito en invalidaciones son recuperados al Control de Balance

### DIFF
--- a/internal/domain/dte/dte_documents/dte_service.go
+++ b/internal/domain/dte/dte_documents/dte_service.go
@@ -55,10 +55,29 @@ func (m *DTEService) GenerateBalanceTransaction(ctx context.Context, branchID ui
 		NotSubjectAmount:     extractor.Summary.TotalNotSubject,
 	}
 
-	// 3. Obtener el control de saldo del DTE
+	// 3. Generar el control de saldo del DTE
 	err = m.repo.GenerateBalanceTransaction(ctx, branchID, originalDTE, &transaction)
 	if err != nil {
 		return shared_error.NewFormattedGeneralServiceWithError("DTEService", "GenerateBalanceTransaction", err, "FailedToGenerateBalanceTransaction")
+	}
+
+	return nil
+}
+
+func (m *DTEService) GenerateBalanceTransactionWithAmounts(ctx context.Context, branchID uint, transactionType, originalDTE, adjustmentDTE string, taxedSale, exemptSale, notSubjectSale float64) error {
+	// 1. Crear la transacción de balance
+	transaction := dte.BalanceTransaction{
+		AdjustmentDocumentID: adjustmentDTE,
+		TransactionType:      transactionType,
+		TaxedAmount:          taxedSale,
+		ExemptAmount:         exemptSale,
+		NotSubjectAmount:     notSubjectSale,
+	}
+
+	// 2. Generar el control de saldo del DTE
+	err := m.repo.GenerateBalanceTransaction(ctx, branchID, originalDTE, &transaction)
+	if err != nil {
+		return shared_error.NewFormattedGeneralServiceWithError("DTEService", "GenerateBalanceTransactionWithAmounts", err, "FailedToGenerateBalanceTransaction")
 	}
 
 	return nil

--- a/internal/domain/dte/dte_documents/dte_service_interface.go
+++ b/internal/domain/dte/dte_documents/dte_service_interface.go
@@ -18,6 +18,8 @@ type DTEManager interface {
 	GetByGenerationCode(ctx context.Context, branchID uint, generationCode string) (*dte.DTEDocument, error)
 	// GenerateBalanceTransaction genera una transacción de balance para un DTE.
 	GenerateBalanceTransaction(ctx context.Context, branchID uint, transactionType, id, originalDTE string, document interface{}) error
+	// GenerateBalanceTransactionWithAmounts genera una transacción de balance con montos específicos.
+	GenerateBalanceTransactionWithAmounts(ctx context.Context, branchID uint, transactionType, originalDTE, adjustmentDTE string, taxedSale, exemptSale, notSubjectSale float64) error
 	// ValidateForCreditNote valida un DTE para la creación de una Nota de Crédito.
 	ValidateForCreditNote(ctx context.Context, branchID uint, originalDTE string, document interface{}) error
 	// GetByGenerationCodeConsult obtiene un DTE por su código de generación para consultas.

--- a/internal/domain/dte/invalidation/invalidation_service.go
+++ b/internal/domain/dte/invalidation/invalidation_service.go
@@ -2,13 +2,16 @@ package invalidation
 
 import (
 	"context"
+
 	"github.com/MarlonG1/api-facturacion-sv/internal/domain/core/dte"
 	"github.com/MarlonG1/api-facturacion-sv/internal/domain/dte/common/constants"
 	"github.com/MarlonG1/api-facturacion-sv/internal/domain/dte/dte_documents"
 	"github.com/MarlonG1/api-facturacion-sv/internal/domain/dte/invalidation/invalidation_models"
 	"github.com/MarlonG1/api-facturacion-sv/internal/domain/dte/invalidation/validator"
 	"github.com/MarlonG1/api-facturacion-sv/pkg/mapper/request_mapper/structs"
+	"github.com/MarlonG1/api-facturacion-sv/pkg/shared/logs"
 	"github.com/MarlonG1/api-facturacion-sv/pkg/shared/shared_error"
+	"github.com/MarlonG1/api-facturacion-sv/pkg/shared/utils"
 )
 
 type invalidationService struct {
@@ -25,10 +28,30 @@ func NewInvalidationService(dteManager dte_documents.DTEManager) InvalidationMan
 }
 
 func (s *invalidationService) InvalidateDocument(ctx context.Context, branchID uint, originalCode string) error {
-	return s.dteManager.UpdateDTE(ctx, branchID, dte.DTEDetails{
+	// 1. Validar el documento de invalidación
+	err := s.dteManager.UpdateDTE(ctx, branchID, dte.DTEDetails{
 		ID:     originalCode,
 		Status: constants.DocumentInvalid,
 	})
+	if err != nil {
+		return shared_error.NewFormattedGeneralServiceError("InvalidationService", "InvalidateDocument", "FailedToInvalidatedDTE")
+	}
+
+	// 2. Obtener el DTE original
+	doc, err := s.dteManager.GetByGenerationCode(ctx, branchID, originalCode)
+	if err != nil {
+		return shared_error.NewFormattedGeneralServiceError("InvalidationService", "InvalidateDocument", "FailedToGetDTE")
+	}
+
+	// 3. Si es Nota de Crédito o Nota de Débito, se debe ajustar el saldo
+	if doc.Details.DTEType == constants.NotaCreditoElectronica || doc.Details.DTEType == constants.NotaDebitoElectronica {
+		err = s.handleControlBalance(ctx, branchID, originalCode, doc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s *invalidationService) Validate(ctx context.Context, branchID uint, document *invalidation_models.InvalidationDocument) error {
@@ -62,6 +85,58 @@ func (s *invalidationService) ValidateStatus(ctx context.Context, branchID uint,
 		}
 	}
 
+	return nil
+}
+
+func (s *invalidationService) handleControlBalance(ctx context.Context, branchID uint, originalCode string, doc *dte.DTEDocument) error {
+	// 1. Extraer los documentos relacionados y los items del DTE
+	extractor := utils.ExtractRelatedDocAndItemsFromStringJSON(doc.Details.JSONData)
+
+	// 2. Crear un mapa para buscar documentos relacionados por número de documento
+	relatedDocsMap := make(map[string]struct {
+		GenerationType int
+		DocumentNumber string
+	})
+	for _, rd := range extractor.RelatedDocs {
+		relatedDocsMap[rd.DocumentNumber] = struct {
+			GenerationType int
+			DocumentNumber string
+		}(rd)
+	}
+
+	// 3. Generar las transacciones de recuperación de saldo para cada item relacionado
+	for _, item := range extractor.Items {
+		relatedDoc, ok := relatedDocsMap[item.RelatedDoc]
+		if ok && relatedDoc.GenerationType == constants.ElectronicDocument {
+			logs.Info("Generating balance control transaction", map[string]interface{}{
+				"branchID":         branchID,
+				"originalCode":     originalCode,
+				"relatedDocument":  relatedDoc.DocumentNumber,
+				"taxedAmount":      item.TaxedAmount,
+				"exemptAmount":     item.ExemptAmount,
+				"notSubjectAmount": item.NotSubjectAmount,
+			})
+
+			if err := s.dteManager.GenerateBalanceTransactionWithAmounts(ctx,
+				branchID,
+				constants.DocumentInvalid,
+				relatedDoc.DocumentNumber,
+				originalCode,
+				item.TaxedAmount,
+				item.ExemptAmount,
+				item.NotSubjectAmount); err != nil {
+				logs.Error("Error generating balance transaction", map[string]interface{}{
+					"error": err.Error(),
+				})
+				return shared_error.NewFormattedGeneralServiceError("InvalidationService", "InvalidateDocument", "FailedToRecoverInvalidatedAmounts")
+			}
+		}
+	}
+
+	logs.Info("Balance control transaction generated successfully, the amounts was added to the balance", map[string]interface{}{
+		"branchID":     branchID,
+		"originalCode": originalCode,
+	})
 	return nil
 }
 

--- a/internal/i18n/en.yaml
+++ b/internal/i18n/en.yaml
@@ -209,6 +209,8 @@ service_errors:
   NotMatchingReceiverNIT: "The receiver NIT in credit note document does not match the NIT in the document to be credited"
   RequestTimeOutTitle: "Request Timeout"
   RequestTimeOut: "The request timeout has expired. This error usually occurs because the Ministry of Finance took a long time to respond. Please try again"
+  FailedToInvalidatedDTE: "There was an error invalidating the DTE, please contact the administrator"
+  FailedToRecoverInvalidatedAmounts: "There was an error retrieving the amounts from the invalidated DTE, please contact the administrator"
 
 health:
   up:

--- a/internal/i18n/es.yaml
+++ b/internal/i18n/es.yaml
@@ -209,6 +209,8 @@ service_errors:
   NotMatchingReceiverNIT: "El NIT del receptor en el documento de nota de crédito no coincide con el NIT del documento a acreditar"
   RequestTimeOutTitle: "Tiempo de espera agotado"
   RequestTimeOut: "El tiempo de espera para la solicitud ha expirado, este error suele aparecer por que el Ministerio de Hacienda tardo mucho en responder, por favor intente nuevamente"
+  FailedToInvalidatedDTE: "Hubo un error al invalidar el DTE, por favor contacte al administrador"
+  FailedToRecoverInvalidatedAmounts: "Hubo un error al recuperar los montos del DTE invalidado, por favor contacte al administrador"
 
 health:
   up:

--- a/internal/infrastructure/database/db_models/dte_balance_transactions.go
+++ b/internal/infrastructure/database/db_models/dte_balance_transactions.go
@@ -14,7 +14,7 @@ type DTEBalanceTransaction struct {
 	ID                   uint      `gorm:"primaryKey;autoIncrement:true;not null;index:idx_dte_balance_transaction"`
 	BalanceControlID     uint      `gorm:"column:balance_control_id;type:int;not null;index:idx_dte_balance_control"`
 	AdjustmentDocumentID string    `gorm:"column:adjustment_document_id;type:varchar(36);not null;index:idx_dte_adjustment_document"`
-	TransactionType      string    `gorm:"column:transaction_type;type:varchar(2);not null;index:idx_dte_transaction_type"`
+	TransactionType      string    `gorm:"column:transaction_type;type:varchar(20);not null;index:idx_dte_transaction_type"`
 	TaxedAmount          float64   `gorm:"column:taxed_amount;type:decimal(18,2);not null"`
 	ExemptAmount         float64   `gorm:"column:exempt_amount;type:decimal(18,2);not null"`
 	NotSubjectAmount     float64   `gorm:"column:not_subject_amount;type:decimal(18,2);not null"`

--- a/pkg/shared/utils/extractors.go
+++ b/pkg/shared/utils/extractors.go
@@ -37,6 +37,19 @@ type AuxiliarDTETotalAmountsExtractor struct {
 	} `json:"summary"`
 }
 
+type AuxiliarRelatedDocAndItemsExtractor struct {
+	RelatedDocs []struct {
+		GenerationType int    `json:"tipoGeneracion"`
+		DocumentNumber string `json:"numeroDocumento"`
+	} `json:"documentoRelacionado"`
+	Items []struct {
+		TaxedAmount      float64 `json:"ventaGravada"`
+		ExemptAmount     float64 `json:"ventaExenta"`
+		NotSubjectAmount float64 `json:"ventaNoSuj"`
+		RelatedDoc       string  `json:"numeroDocumento"`
+	} `json:"cuerpoDocumento"`
+}
+
 func ExtractAuxiliarIdentification(document interface{}) (AuxiliarIdentificationExtractor, error) {
 	var identification AuxiliarIdentificationExtractor
 
@@ -97,6 +110,17 @@ func ExtractSummaryTotalAmountsFromStringJSON(document interface{}) (AuxiliarTot
 	}
 
 	return summary, nil
+}
+
+func ExtractRelatedDocAndItemsFromStringJSON(document interface{}) AuxiliarRelatedDocAndItemsExtractor {
+	var relatedDocAndItems AuxiliarRelatedDocAndItemsExtractor
+
+	// 1. Convertir a formato JSON el documento
+	jsonData := []byte(document.(string))
+
+	// 2. Extraer parte de la información del Resumen
+	_ = json.Unmarshal(jsonData, &relatedDocAndItems)
+	return relatedDocAndItems
 }
 
 func ExtractDTEReceiverFromString(document interface{}) (AuxiliarReceiverExtractor, error) {

--- a/tests/services/invalidation_service_test.go
+++ b/tests/services/invalidation_service_test.go
@@ -390,6 +390,17 @@ func TestInvalidationServiceInvalidateDocument(t *testing.T) {
 						Status: constants.DocumentInvalid,
 					},
 				).Return(nil)
+
+				mockDTE.EXPECT().GetByGenerationCode(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(&dte.DTEDocument{
+					Details: &dte.DTEDetails{
+						ID:      "DTE-01-00000001-000000000000001",
+						DTEType: constants.CCFElectronico,
+					},
+				}, nil)
 			},
 			wantErr: false,
 		},
@@ -403,10 +414,10 @@ func TestInvalidationServiceInvalidateDocument(t *testing.T) {
 						ID:     "DTE-01-00000001-000000000000001",
 						Status: constants.DocumentInvalid,
 					},
-				).Return(shared_error.NewGeneralServiceError("DTEManager", "UpdateDTE", "Failed to update document status", nil))
+				).Return(errors.New("any error"))
 			},
 			wantErr:   true,
-			errorCode: "Failed to update document status",
+			errorCode: "FailedToInvalidatedDTE",
 		},
 	}
 


### PR DESCRIPTION
Esta solicitud de incorporación de cambios introduce actualizaciones significativas al servicio `DTE` (Documento Tributario Electrónico), centrándose en la gestión de transacciones de saldo, los procesos de invalidación y las utilidades relacionadas. Los cambios incluyen nuevos métodos para generar transacciones de saldo con importes específicos, mejoras en el servicio de invalidación para gestionar ajustes de saldo y actualizaciones de las utilidades compartidas y los mensajes de error. A continuación, se presenta un resumen de los cambios más importantes agrupados por tema:

### Mejoras en las Transacciones de Saldo
* Se ha añadido el nuevo método `GenerateBalanceTransactionWithAmounts` en `DTEService` para crear transacciones de saldo con importes específicos (`taxedSale`, `exemptSale`, `notSubjectSale`). Esto complementa el método `GenerateBalanceTransaction` existente. (`internal/domain/dte/dte_documents/dte_service.go`, [internal/domain/dte/dte_documents/dte_service.goR67-R85](diffhunk://#diff-9ef97b8954988f21115f990aa110546284e281cfdba62fd862609fcd30f4aaf0R67-R85))
* Se actualizó la interfaz `DTEManager` para incluir el nuevo método `GenerateBalanceTransactionWithAmounts`. (`internal/domain/dte/dte_documents/dte_service_interface.go`, [internal/domain/dte/dte_documents/dte_service_interface.goR21-R22](diffhunk://#diff-8b71f2bfe01be4bc8e995984043af9eb5c926d0724753ad727d50b71677924deR21-R22))
* Se modificó el campo `TransactionType` en el modelo de base de datos `DTEBalanceTransaction` para aumentar su longitud de 2 a 20 caracteres, lo que permite tipos de transacción más descriptivos. (`internal/infrastructure/database/db_models/dte_balance_transactions.go`, [internal/infrastructure/database/db_models/dte_balance_transactions.goL17-R17](diffhunk://#diff-fb246397534dc5968e38fdeb90bfb68f463e92a93f6ad24ed6e6fdfb098d943cL17-R17))

### Mejoras en el Servicio de Invalidación
* Se mejoró el método `InvalidateDocument` para validar el documento, recuperar el DTE original y gestionar los ajustes de saldo de las notas de crédito y débito. (`internal/domain/dte/invalidation/invalidation_service.go`, [internal/domain/dte/invalidation/invalidation_service.goL28-R54](diffhunk://#diff-d102ccd14d69898800fcbd8aebd1696aa77b19b729ae2f11116ef38181f54e66L28-R54))
* Se introdujo un nuevo método auxiliar `handleControlBalance` para generar transacciones de recuperación de saldo para documentos relacionados durante la invalidación. (`internal/domain/dte/invalidation/invalidation_service.go`, [internal/domain/dte/invalidation/invalidation_service.goR91-R142](diffhunk://#diff-d102ccd14d69898800fcbd8aebd1696aa77b19b729ae2f11116ef38181f54e66R91-R142))

### Actualizaciones de utilidades
* Se agregó una nueva estructura `AuxiliarRelatedDocAndItemsExtractor` y su método correspondiente `ExtractRelatedDocAndItemsFromStringJSON` para extraer documentos y elementos relacionados de los datos JSON. Esto es compatible con la nueva lógica de ajuste de saldo. (`pkg/shared/utils/extractors.go`, [[1]](diffhunk://#diff-06b3f0e00523887193fbe34623c8a310ba631a8ef46cbc9e5f988452418f3a23R40-R52) [[2]](diffhunk://#diff-06b3f0e00523887193fbe34623c8a310ba631a8ef46cbc9e5f988452418f3a23R115-R125)

### Localización y gestión de errores
* Se añadieron nuevos mensajes de error para procesos de invalidación y recuperación de saldo fallidos en los archivos de localización en inglés y español. (`internal/i18n/en.yaml`, [[1]](diffhunk://#diff-46f8af0b0dff20a92c3c4da5ac3532f53facf24853210dee8f8c06ea2d258a45R212-R213); `internal/i18n/es.yaml`, [[2]](diffhunk://#diff-07aad0225834e9c47875692a1ecf82eadd27da6cd29836d93c9bc10ebd70a215R212-R213)

### Cobertura de la prueba
* Se actualizó el caso de prueba `InvalidateDocument` para incluir escenarios para recuperar el DTE original y gestionar errores durante la invalidación. (`tests/services/invalidation_service_test.go`, [[1]](diffhunk://#diff-4164510486c7feebfede821772eb72f097062938c1f4256ba328e8ebfde7a321R393-R403) [[2]](diffhunk://#diff-4164510486c7feebfede821772eb72f097062938c1f4256ba328e8ebfde7a321L406-R420)